### PR TITLE
docs: Remove workarounds from example.ks

### DIFF
--- a/docs/example.ks
+++ b/docs/example.ks
@@ -2,11 +2,9 @@ text
 
 # Basic partitioning
 clearpart --all --initlabel --disklabel=gpt
-part prepboot  --size=4    --fstype=prepboot
-part biosboot  --size=1    --fstype=biosboot
-part /boot/efi --size=100  --fstype=efi
-part /boot     --size=1000  --fstype=ext4 --label=boot
+part /boot --size=1000  --fstype=ext4 --label=boot
 part / --grow --fstype xfs
+reqpart
 
 ostreecontainer --url quay.io/centos-bootc/fedora-bootc:eln	--no-signature-verification
 # Or: quay.io/centos-bootc/centos-bootc-dev:stream9

--- a/docs/example.ks
+++ b/docs/example.ks
@@ -1,5 +1,7 @@
 text
-
+# NOTE: As of the time of this writing, this kickstart only
+# works with a Fedora 40+ (or ELN) installer ISO as it requires
+# https://github.com/rhinstaller/anaconda/pull/5342
 # Basic partitioning
 clearpart --all --initlabel --disklabel=gpt
 part /boot --size=1000  --fstype=ext4 --label=boot

--- a/docs/example.ks
+++ b/docs/example.ks
@@ -19,14 +19,3 @@ rootpw --iscrypted locked
 # Add your example SSH key here!
 #sshkey --username root "ssh-ed25519 <key> demo@example.com"
 reboot
-
-# Workarounds until https://github.com/rhinstaller/anaconda/pull/5298/ lands
-bootloader --location=none --disabled
-%post --erroronfail
-set -euo pipefail
-# Work around anaconda wanting a root password
-passwd -l root
-rootdevice=$(findmnt -nv -o SOURCE /)
-device=$(lsblk -n -o PKNAME ${rootdevice})
-/usr/bin/bootupctl backend install --auto --with-static-configs --device /dev/${device} /
-%end


### PR DESCRIPTION
The partitioning defined in the example kickstart file suggests that the
installer supports hybrid boot. That's misleading and not true. Let's use
the `reqpart` kickstart command to automatically create partitions required
by the detected platform instead of creating all of them for all platforms.

**Note:** The `reqpart` command doesn't work with `bootloader --location=none` or
`bootloader --disabled`, so this change depends on the installer's support
for bootupd.

**Depends on:** https://github.com/rhinstaller/anaconda/pull/5298