### PR TITLE
Fix cat redirection

### DIFF
--- a/tier-0/initramfs.yaml
+++ b/tier-0/initramfs.yaml
@@ -3,7 +3,7 @@ postprocess:
   - |
     #!/usr/bin/env bash
     mkdir -p /usr/lib/dracut/dracut.conf.d
-    cat > /usr/lib/dracut/dracut.conf.d/01-bootc-nohostonly.conf
+    cat > /usr/lib/dracut/dracut.conf.d/01-bootc-nohostonly.conf << 'EOF'
     # We want a generic image; hostonly makes no sense as part of a server side build
     hostonly=no
     EOF


### PR DESCRIPTION
Just a small fix, adding a missing redirection so that '01-bootc-nohostonly.conf' is not created empty.
Since dracut's default is 'hostonly=no' this fix has no impact on the initramfs contents.