### PR TITLE
docs/install: Add ssh-key-dir workaround

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -78,11 +78,13 @@ There's a provisional KVM guest image uploaded here:
 
 [Fedora CoreOS](https://docs.fedoraproject.org/en-US/fedora-coreos/) supports
 many different platforms, and can be used as a starting point to "rebase" to a
-custom derived image from CentOS boot.
+custom derived image from CentOS boot.  These commands should all be invoked
+as root.
 
 ```shell
 systemctl mask --now zincati && rm -vf /run/ostree/staged-deployment-locked
 echo "# dummy change" >> "/etc/sudoers.d/coreos-sudo-group"
+cp -a ~core/.ssh/authorized_keys.d/ignition ~core/.ssh/authorized_keys
 rpm-ostree rebase ostree-unverified-registry:quay.io/centos-bootc/fedora-bootc:eln
 systemctl reboot
 ```


### PR DESCRIPTION
We broke the FCOS switch with ec478a0a1be1c9a8b1fe46704f6954b88b2618d4 because `ssh-key-dir` is not in ELN.  That's fixable but for now let's document the current state.