### PR TITLE
tekton: Fix duplicate s390x, use ppc64le

### DIFF
--- a/.tekton/ostree-build.yaml
+++ b/.tekton/ostree-build.yaml
@@ -340,7 +340,7 @@ spec:
         - name: COMMIT_SHA
           value: $(tasks.clone-repository.results.commit)
         - name: PLATFORM
-          value: linux/s390x
+          value: linux/ppc64le
         - name: BUILDER_IMAGE
           value: quay.io/centos-bootc/builder:latest
       runAfter:


### PR DESCRIPTION
This was a copy-paste failure; we were intending to build ppc64le here.