### PR TITLE
ostree: Enable root.transient = true by default

### DIFF
--- a/tier-0/ostree.yaml
+++ b/tier-0/ostree.yaml
@@ -7,6 +7,8 @@ postprocess:
     #!/usr/bin/env bash
     mkdir -p /usr/lib/ostree
     cat > /usr/lib/ostree/prepare-root.conf << EOF
+    [root]
+    transient = true
     [sysroot]
     readonly = true
     EOF


### PR DESCRIPTION
This turns on the functionality added in
https://github.com/ostreedev/ostree/pull/3114