### PR TITLE
Always add bootc install config

### DIFF
--- a/tier-0/bootc-config.yaml
+++ b/tier-0/bootc-config.yaml
@@ -1,0 +1,10 @@
+# Configuration for bootc
+postprocess:
+  # XFS is our default filesystem
+  - |
+    #!/usr/bin/env bash
+    mkdir -p /usr/lib/bootc/install/
+    cat > /usr/lib/bootc/install/20-rhel.toml << EOF
+    [install]
+    root-fs-type = "xfs"
+    EOF

--- a/tier-0/bootc.yaml
+++ b/tier-0/bootc.yaml
@@ -10,13 +10,3 @@ exclude-packages:
   # chosen as the package to satisfy the `kernel-core` dependency from
   # the kernel package.
   - kernel-debug-core
-
-postprocess:
-  # XFS is our default filesystem
-  - |
-    #!/usr/bin/env bash
-    mkdir -p /usr/lib/bootc/install/
-    cat > /usr/lib/bootc/install/20-rhel.toml << EOF
-    [install]
-    root-fs-type = "xfs"
-    EOF

--- a/tier-0/manifest.yaml
+++ b/tier-0/manifest.yaml
@@ -55,6 +55,7 @@ conditional-include:
 
 include:
   - ostree.yaml
+  - bootc-config.yaml
   - initramfs.yaml
 
 packages:

--- a/tier-1/bootc-config.yaml
+++ b/tier-1/bootc-config.yaml
@@ -1,0 +1,1 @@
+../tier-0/bootc-config.yaml


### PR DESCRIPTION
bootc isn't in C9S yet, but it is in the -dev images.  Add the install config unconditionally so that `bootc install` works in the `centos-bootc-dev` image.