### PR TITLE
Dracut fixes

### DIFF
--- a/tier-0/initramfs.yaml
+++ b/tier-0/initramfs.yaml
@@ -6,7 +6,7 @@ postprocess:
     cat > /usr/lib/dracut/dracut.conf.d/20-bootc-base.conf << 'EOF'
     # We want a generic image; hostonly makes no sense as part of a server side build
     hostonly=no
-    dracutmodules+=" kernel-modules dracut-systemd systemd-initrd base "
+    dracutmodules+=" kernel-modules dracut-systemd systemd-initrd base ostree "
     EOF
     cat > /usr/lib/dracut/dracut.conf.d/49-bootc-tpm2-tss.conf << 'EOF'
     # We want this for systemd-cryptsetup tpm2 locking

--- a/tier-0/initramfs.yaml
+++ b/tier-0/initramfs.yaml
@@ -3,7 +3,7 @@ postprocess:
   - |
     #!/usr/bin/env bash
     mkdir -p /usr/lib/dracut/dracut.conf.d
-    cat > /usr/lib/dracut/dracut.conf.d/01-bootc-nohostonly.conf << 'EOF'
+    cat > /usr/lib/dracut/dracut.conf.d/20-bootc-nohostonly.conf << 'EOF'
     # We want a generic image; hostonly makes no sense as part of a server side build
     hostonly=no
     EOF
@@ -11,6 +11,6 @@ postprocess:
     # We want this for systemd-cryptsetup tpm2 locking
     dracutmodules+=" tpm2-tss "
     EOF
-    cat > /usr/lib/dracut/dracut.conf.d/01-centos-bootc-base.conf << 'EOF'
+    cat > /usr/lib/dracut/dracut.conf.d/20-centos-bootc-base.conf << 'EOF'
     dracutmodules+=" kernel-modules dracut-systemd systemd-initrd base "
     EOF

--- a/tier-0/initramfs.yaml
+++ b/tier-0/initramfs.yaml
@@ -3,14 +3,12 @@ postprocess:
   - |
     #!/usr/bin/env bash
     mkdir -p /usr/lib/dracut/dracut.conf.d
-    cat > /usr/lib/dracut/dracut.conf.d/20-bootc-nohostonly.conf << 'EOF'
+    cat > /usr/lib/dracut/dracut.conf.d/20-bootc-base.conf << 'EOF'
     # We want a generic image; hostonly makes no sense as part of a server side build
     hostonly=no
+    dracutmodules+=" kernel-modules dracut-systemd systemd-initrd base "
     EOF
-    cat > /usr/lib/dracut/dracut.conf.d/49-tpm2-tss.conf << 'EOF'
+    cat > /usr/lib/dracut/dracut.conf.d/49-bootc-tpm2-tss.conf << 'EOF'
     # We want this for systemd-cryptsetup tpm2 locking
     dracutmodules+=" tpm2-tss "
-    EOF
-    cat > /usr/lib/dracut/dracut.conf.d/20-centos-bootc-base.conf << 'EOF'
-    dracutmodules+=" kernel-modules dracut-systemd systemd-initrd base "
     EOF


### PR DESCRIPTION
initramfs: Move our dracut config later

Our hostonly setting was conflicting with the default
`hostonly=yes` in `01-dist.conf`.

---

initramfs: Consolidate and rename drop-initramfs

No reason to have the "base" settings in distinct files.

---

