### PR TITLE
tier-0: bootc is only in eln

### DIFF
--- a/tier-0/manifest.yaml
+++ b/tier-0/manifest.yaml
@@ -50,7 +50,7 @@ remove-from-packages:
   - [dbus-common, /usr/lib/sysusers.d/dbus.conf]
 
 conditional-include:
-  - if: distro != "stream9"
+  - if: distro == "eln"
     include: bootc.yaml
 
 include:


### PR DESCRIPTION
Prep for building with non-stream9 distros.

(TODO: add a dedicated variable for this at the toplevel)