### PR TITLE
Add subscription-manager

### DIFF
--- a/tier-1/manifest.yaml
+++ b/tier-1/manifest.yaml
@@ -4,7 +4,7 @@ recommends: true
 include:
   - manifest-tier-0.yaml
   - bootable-rpm-ostree.yaml
-  - dnf.yaml
+  - rpm-packaging.yaml
   - podman.yaml
   - firmware.yaml
   - networking-tools.yaml

--- a/tier-1/rpm-packaging.yaml
+++ b/tier-1/rpm-packaging.yaml
@@ -2,3 +2,5 @@
 # `dnf update` *client side* doesn't do much helpful...
 packages:
   - dnf
+  # To ensure we can enable client certs to access RHEL content
+  - subscription-manager


### PR DESCRIPTION
We need this to access RHEL RPM content today.

(I would like longer term to be able to fetch RPMs from registries
 with a pull secret, xref https://github.com/coreos/rpm-ostree/issues/4155 )