### PR TITLE
Enable `bootc-fetch-apply-updates.service` by default

### DIFF
--- a/tier-0/autoupdates.yaml
+++ b/tier-0/autoupdates.yaml
@@ -1,0 +1,11 @@
+# Enable automatic updates by default
+
+# Configuration for bootc
+postprocess:
+  - |
+    #!/usr/bin/env bash
+    set -euo pipefail
+    target=/usr/lib/systemd/system/default.target.wants
+    mkdir -p $target
+    set -x
+    ln -s ../bootc-fetch-apply-updates.service $target

--- a/tier-0/manifest.yaml
+++ b/tier-0/manifest.yaml
@@ -54,6 +54,7 @@ include:
   - ostree.yaml
   - bootc-config.yaml
   - initramfs.yaml
+  - autoupdates.yaml
 
 packages:
   # Even in tier-0, we have this.  If you don't want SELinux today, you'll need

--- a/tier-1/autoupdates.yaml
+++ b/tier-1/autoupdates.yaml
@@ -1,0 +1,1 @@
+../tier-0/autoupdates.yaml


### PR DESCRIPTION
This landed in https://github.com/containers/bootc/pull/179/commits/c13c9eb8dcd829db0b8d35a526ee7a0e9bc91e97 And we want to come out emphasizing it.