### PR TITLE
chore: add backstage component descriptor file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: centos-bootc
+  annotations:
+    github.com/project-slug: CentOS/centos-bootc
+spec:
+  type: other
+  lifecycle: experimental
+  owner: redhat/platform-engineering


### PR DESCRIPTION
Enable integration with a backstage based software catalog by adding the [backstage component descriptor file](https://backstage.io/docs/features/software-catalog/descriptor-format)