### PR TITLE
tier-1: Enable lvm dracut module

### DIFF
--- a/tier-1/initramfs-full.yaml
+++ b/tier-1/initramfs-full.yaml
@@ -1,0 +1,8 @@
+# Configuration for the "tier-1" initramfs
+postprocess:
+  - |
+    #!/usr/bin/env bash
+    mkdir -p /usr/lib/dracut/dracut.conf.d
+    cat > /usr/lib/dracut/dracut.conf.d/30-bootc-tier-1.conf << 'EOF'
+    dracutmodules+=" lvm "
+    EOF

--- a/tier-1/manifest.yaml
+++ b/tier-1/manifest.yaml
@@ -12,6 +12,7 @@ include:
   - user-experience.yaml
   - fwupd.yaml
   - persistent-journal.yaml
+  - initramfs-full.yaml
 
 packages:
   # Include and set the default editor


### PR DESCRIPTION
Right now we have an "allowlist" effectively for our dracut modules because we specify a configuration in `/usr/lib/dracut/dracut.conf.d` which seems to turn off autodetection.

Add in lvm which we definitely want to support.