### PR TITLE
docs/install: Doc direct bootc raw and systemd creds

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -26,6 +26,27 @@ supports generating disk images, including injecting user accounts.
 
 NOTE: this tool [does not yet work with centos stream 9](https://github.com/osbuild/bootc-image-builder/issues/20).
 
+## Generating a raw disk image that can be launched via virt tooling
+
+The above bootc-image-builder tool can generate disk images; however, a key part
+of the idea of `bootc` is that operating system images that use it are their
+own self-sufficient "baseline" installer.  So you can use this example:
+
+<https://github.com/containers/bootc/blob/main/docs/install.md#using-bootc-install-to-disk---via-loopback>
+
+to generate a raw disk image from the default container base image, or your own
+without any external tooling.
+
+If you choose not to include SSH keys or other credentials directly in your image,
+a useful pattern can often be to use [systemd credentials](https://systemd.io/CREDENTIALS/)
+to inject a SSH key for root.  The above page has this example for qemu:
+
+```bash
+-smbios type=11,value=io.systemd.credential.binary:tmpfiles.extra=$(echo "f~ /root/.ssh/authorized_keys 600 root root - $(ssh-add -L | base64 -w 0)" | base64 -w 0)
+```
+
+Unlike current bootc-image-builder, this flow works with current CentOS Stream 9.
+
 ## Installation using Anaconda
 
 Tools like

--- a/docs/install.md
+++ b/docs/install.md
@@ -24,8 +24,6 @@ helps automate this.
 The [bootc-image-builder tool](https://github.com/osbuild/bootc-image-builder)
 supports generating disk images, including injecting user accounts.
 
-NOTE: this tool [does not yet work with centos stream 9](https://github.com/osbuild/bootc-image-builder/issues/20).
-
 ## Generating a raw disk image that can be launched via virt tooling
 
 The above bootc-image-builder tool can generate disk images; however, a key part
@@ -44,8 +42,6 @@ to inject a SSH key for root.  The above page has this example for qemu:
 ```bash
 -smbios type=11,value=io.systemd.credential.binary:tmpfiles.extra=$(echo "f~ /root/.ssh/authorized_keys 600 root root - $(ssh-add -L | base64 -w 0)" | base64 -w 0)
 ```
-
-Unlike current bootc-image-builder, this flow works with current CentOS Stream 9.
 
 ## Installation using Anaconda
 


### PR DESCRIPTION
Let's link to the existing docs for using `bootc install to-disk` which fixes some bugs, though we aim to make bib a primary entrypoint for disks.

Second: Let's document using systemd credentials to inject a root SSH key, because this works across every image we ship where one can inject SMBIOS bits.  (But notably this doesn't work in most production IaaS virt systems like KubeVirt, AWS etc. which gets into cloud agents).