### PR TITLE
initramfs: Add virtiofs

### DIFF
--- a/tier-0/initramfs.yaml
+++ b/tier-0/initramfs.yaml
@@ -8,6 +8,10 @@ postprocess:
     hostonly=no
     dracutmodules+=" kernel-modules dracut-systemd systemd-initrd base ostree "
     EOF
+    cat > /usr/lib/dracut/dracut.conf.d/22-bootc-generic.conf << 'EOF'
+    # Extra modules that we want by default that are known to exist in the kernel
+    dracutmodules+=" virtiofs "
+    EOF
     cat > /usr/lib/dracut/dracut.conf.d/49-bootc-tpm2-tss.conf << 'EOF'
     # We want this for systemd-cryptsetup tpm2 locking
     dracutmodules+=" tpm2-tss "


### PR DESCRIPTION
Today it's built as a module for Fedora derivatives, but it's a relatively small kmod.

In particular I want to be able to use a virtiofs root as a bootstrap mechanism to generate disk images in a situation where we can't do nested containers, but we do have `/dev/kvm` - which is the setup we have in e.g. OpenShift Prow on `build02` with nested virt.