### PR TITLE
Start with an empty `/etc/machine-id` to disable `ConditionFirstBoot`

### DIFF
--- a/tier-0/manifest.yaml
+++ b/tier-0/manifest.yaml
@@ -2,9 +2,8 @@
 # Modern defaults we want
 boot-location: modules
 tmp-is-dir: true
-# This one at least historically broke compatibility with Anaconda, but
-# let's use it by default now.
-machineid-compat: false
+# https://github.com/CentOS/centos-bootc/issues/167
+machineid-compat: true
 # Be minimal
 recommends: false
 


### PR DESCRIPTION
The systemd firstboot process does several things, but notably it runs a preset process.  This means that basically a plain `RUN systemctl enable foo` won't work unless you *also* write a preset file for it, and no one will know to do that.

Closes: https://github.com/CentOS/centos-bootc/issues/167