### PR TITLE
tier-1: Enable dracut crypt module too

### DIFF
--- a/tier-1/initramfs-full.yaml
+++ b/tier-1/initramfs-full.yaml
@@ -4,5 +4,5 @@ postprocess:
     #!/usr/bin/env bash
     mkdir -p /usr/lib/dracut/dracut.conf.d
     cat > /usr/lib/dracut/dracut.conf.d/30-bootc-tier-1.conf << 'EOF'
-    dracutmodules+=" lvm "
+    dracutmodules+=" lvm crypt "
     EOF


### PR DESCRIPTION

We want to support LUKS encrypted root filesystems in general.
We're shipping the code in the root, so we might as well enable
it in the initramfs.

---

