### PR TITLE
Add a `containers.bootc` label

### DIFF
--- a/centos-bootc-config.json
+++ b/centos-bootc-config.json
@@ -1,5 +1,6 @@
 {
     "Labels": {
+        "containers.bootc": "1",
         "redhat.compose-id": "CentOS-Stream-9-20240205.d.0",
         "redhat.id": "centos",
         "redhat.version-id": "9"

--- a/fedora-bootc-config.json
+++ b/fedora-bootc-config.json
@@ -1,5 +1,6 @@
 {
     "Labels": {
+        "containers.bootc": "1",
         "redhat.compose-id": "Fedora-ELN-20240205.2",
         "redhat.id": "fedora",
         "redhat.version-id": "ELN"


### PR DESCRIPTION
Pairs with https://github.com/containers/bootc/pull/299

This is intended to be the new canonical label for bootc-compatible images, as opposed to the existing `ostree.linux` etc.