### PR TITLE
tmt: comment out the code in tmt plan which access to quay.io

### DIFF
--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -26,5 +26,8 @@ execute:
 
         # Then, perform some check
         for IMAGE in $IMAGES; do
-            podman run $IMAGE cat /etc/os-release
+            echo $IMAGE
+            # Comment out this line due to the quay.io flakes
+            # https://github.com/containers/podman/issues/16973
+            # podman run $IMAGE cat /etc/os-release
         done


### PR DESCRIPTION
It's a know issue and already has workaround
https://github.com/containers/podman/issues/16973

Comment out the line to not let it block the CI pipeline, since this part is just copied from a demo template.