### PR TITLE
manifests/bootupd: Drop unnecessary /

### DIFF
--- a/tier-0/bootupd.yaml
+++ b/tier-0/bootupd.yaml
@@ -28,4 +28,4 @@ postprocess:
     # Until we have https://github.com/coreos/rpm-ostree/pull/2275
     mkdir -p /run
     # Transforms /usr/lib/ostree-boot into a bootupd-compatible update payload
-    /usr/bin/bootupctl backend generate-update-metadata /
+    /usr/bin/bootupctl backend generate-update-metadata


### PR DESCRIPTION
It's not supported to pass anything other than `/` now, and the argument has been optional for some time.