### PR TITLE
build: Use bib

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: quay.io/centos-bootc/builder:latest
+      image: quay.io/centos-bootc/bootc-image-builder:latest
       options: --privileged
 
     strategy:

--- a/.tekton/ostree-build.yaml
+++ b/.tekton/ostree-build.yaml
@@ -179,7 +179,7 @@ spec:
         - name: PLATFORM
           value: linux/amd64
         - name: BUILDER_IMAGE
-          value: quay.io/centos-bootc/builder:latest
+          value: quay.io/centos-bootc/bootc-image-builder:latest
         - name: CONFIG_FILE
           value: $(params.config-file)
       runAfter:
@@ -216,7 +216,7 @@ spec:
         - name: PLATFORM
           value: linux/arm64
         - name: BUILDER_IMAGE
-          value: quay.io/centos-bootc/builder:latest
+          value: quay.io/centos-bootc/bootc-image-builder:latest
         - name: CONFIG_FILE
           value: $(params.config-file)
       runAfter:

--- a/renovate.json
+++ b/renovate.json
@@ -68,7 +68,7 @@
     },
     {
       "matchPackageNames": [
-        "quay.io/centos-bootc/builder"
+        "quay.io/centos-bootc/bootc-image-builder"
       ],
       "pinDigests": false
     }


### PR DESCRIPTION
- It's not worth shipping around a distinct build container; bootc-image-builder already has all the dependencies we need since https://github.com/osbuild/bootc-image-builder/pull/176/commits/44d15acded8641499ea6b4c5d2acceb1bd9694b2
- I'd like to add a more first-class mechanism in bib to build base images