### PR TITLE
tier-0: Enable tmp.mount by default

### DIFF
--- a/tier-0/basic-fixes.yaml
+++ b/tier-0/basic-fixes.yaml
@@ -1,0 +1,19 @@
+# Fix general bugs
+
+postprocess:
+  # See also https://github.com/openshift/os/blob/f6cde963ee140c02364674db378b2bc4ac42675b/common.yaml#L156
+  # This one is undoes the effect of
+  # # RHEL-only: Disable /tmp on tmpfs.
+  #Wants=tmp.mount
+  # in /usr/lib/systemd/system/basic.target
+  # We absolutely must have tmpfs-on-tmp for multiple reasons,
+  # but the biggest is that when we have composefs for / it's read-only,
+  # and for units with ProtectSystem=full systemd clones / but needs
+  # a writable place.
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    mkdir -p /usr/lib/systemd/system/local-fs.target.wants
+    if test '!' -f /usr/lib/systemd/system/local-fs.target.wants/tmp.mount; then
+      ln -sf ../tmp.mount /usr/lib/systemd/system/local-fs.target.wants
+    fi

--- a/tier-0/manifest.yaml
+++ b/tier-0/manifest.yaml
@@ -54,6 +54,7 @@ include:
   - bootc-config.yaml
   - initramfs.yaml
   - autoupdates.yaml
+  - basic-fixes.yaml
 
 packages:
   # Even in tier-0, we have this.  If you don't want SELinux today, you'll need

--- a/tier-1/basic-fixes.yaml
+++ b/tier-1/basic-fixes.yaml
@@ -1,0 +1,1 @@
+../tier-0/basic-fixes.yaml


### PR DESCRIPTION
The long-carried-forward patch to disable `tmp.mount` for RHEL rears its head again.