### PR TITLE
Add `VOLUME /var` into container config by default

### DIFF
--- a/centos-bootc-config.json
+++ b/centos-bootc-config.json
@@ -4,5 +4,8 @@
         "redhat.compose-id": "CentOS-Stream-9-20240212.d.0",
         "redhat.id": "centos",
         "redhat.version-id": "9"
+    },
+    "Volumes": {
+        "/var": {}
     }
 }

--- a/fedora-bootc-config.json
+++ b/fedora-bootc-config.json
@@ -4,5 +4,8 @@
         "redhat.compose-id": "Fedora-ELN-20240213.3",
         "redhat.id": "fedora",
         "redhat.version-id": "ELN"
+    },
+    "Volumes": {
+        "/var": {}
     }
 }


### PR DESCRIPTION
This meshes with
<https://github.com/ostreedev/ostree/pull/3166/commits/f81b9fa1666c62a024d5ca0bbe876321f72529c7> in that our container image now behaves by default similarly to how the host works at runtime.