### PR TITLE
Swap to nfs-utils, not nfs-utils-coreos

### DIFF
--- a/tier-1/manifest.yaml
+++ b/tier-1/manifest.yaml
@@ -17,8 +17,7 @@ include:
 packages:
   # Include and set the default editor
   - nano
-  # Minimal NFS client
-  - nfs-utils-coreos
+  - nfs-utils
   # Additional firewall support; we aren't including these in RHCOS or they
   # don't exist in RHEL
   - iptables-nft iptables-services


### PR DESCRIPTION
The `nfs-utils-coreos` package was created to not depend on Python mainly, but we are way deep into many other packages that do at this point.

There's some other package that `Requires: nfs-utils` that this should fix.