### PR TITLE
Revert "Add `VOLUME /var` into container config by default"

### DIFF
--- a/centos-bootc-config.json
+++ b/centos-bootc-config.json
@@ -4,8 +4,5 @@
         "redhat.compose-id": "CentOS-Stream-9-20240212.d.0",
         "redhat.id": "centos",
         "redhat.version-id": "9"
-    },
-    "Volumes": {
-        "/var": {}
     }
 }

--- a/fedora-bootc-config.json
+++ b/fedora-bootc-config.json
@@ -4,8 +4,5 @@
         "redhat.compose-id": "Fedora-ELN-20240214.2",
         "redhat.id": "fedora",
         "redhat.version-id": "ELN"
-    },
-    "Volumes": {
-        "/var": {}
     }
 }


### PR DESCRIPTION
This reverts commit 7966e8931bf282b3fc0eef0b7153fba7b789dc94. It just breaks derived builds across the board.