### PR TITLE
manifest: Drop rpm-ostree by default

### DIFF
--- a/tier-1/bootable-rpm-ostree.yaml
+++ b/tier-1/bootable-rpm-ostree.yaml
@@ -1,8 +1,0 @@
-packages:
- - rpm-ostree nss-altfiles
-
-exclude-packages:
-  # Exclude kernel-debug-core to make sure that it doesn't somehow get
-  # chosen as the package to satisfy the `kernel-core` dependency from
-  # the kernel package.
-  - kernel-debug-core

--- a/tier-1/manifest.yaml
+++ b/tier-1/manifest.yaml
@@ -3,7 +3,6 @@ recommends: true
 
 include:
   - manifest-tier-0.yaml
-  - bootable-rpm-ostree.yaml
   - rpm-packaging.yaml
   - podman.yaml
   - firmware.yaml


### PR DESCRIPTION
This came out of discussion in https://github.com/CentOS/centos-bootc-dev/pull/27

Basically...I think what we should emphasize in the future is the combination of `bootc` and `dnf`.

There's no really strong reason to use `rpm-ostree` at container build time versus `dnf`.  Now on the *client* side...well, here's the interesting thing; with transient root enabled, `dnf install` etc generally just works.

Of course, *persistent* changes don't.  However, anyone who wants that can just `dnf install rpm-ostree` in their container builds.

There is one gap that's somewhat important which is kernel arguments. Because we haven't taught `grubby` do deal with ostree, and we don't have https://github.com/containers/bootc/issues/255 to change kargs per machine outside of install time one will need to just hand-edit the configs in `/boot/loader`.

Another fallout from this is that `ostree container` goes away inside the booted host...and today actually this totally breaks bib until https://github.com/osbuild/bootc-image-builder/issues/18 is fixed.

Probably bootc should grow the interception for that too optionally.