### PR TITLE
ci: override the GIT_URL & GIT_REF from SNAPSHOT

### DIFF
--- a/.tekton/testing-farm.yaml
+++ b/.tekton/testing-farm.yaml
@@ -54,6 +54,11 @@ spec:
 
         export TESTING_FARM_API_TOKEN=$(cat /etc/secrets/testing-farm-token)
 
+        apk add jq
+
+        GIT_URL=$(echo "${SNAPSHOT}" | jq -r '.components[0].source.git.url')
+        GIT_REF=$(echo "${SNAPSHOT}" | jq -r '.components[0].source.git.revision')
+
         testing-farm request \
           --environment SNAPSHOT="$(echo ${SNAPSHOT} | base64 -w 0)" \
           --git-url "${GIT_URL}" \


### PR DESCRIPTION
bib team has tmt metadata define in this repo, in order to test the tmt code changes along with PR, we need to change the git ref.