### PR TITLE
Enable composefs root 

### DIFF
--- a/copr-walters-fasttracks.repo
+++ b/copr-walters-fasttracks.repo
@@ -8,4 +8,3 @@ gpgkey=https://download.copr.fedorainfracloud.org/results/walters/fedora-bootc-f
 repo_gpgcheck=0
 enabled=1
 enabled_metadata=1
-

--- a/tier-0/ostree.yaml
+++ b/tier-0/ostree.yaml
@@ -7,9 +7,8 @@ postprocess:
     #!/usr/bin/env bash
     mkdir -p /usr/lib/ostree
     cat > /usr/lib/ostree/prepare-root.conf << EOF
-    # TODO disabled due to https://github.com/osbuild/bootc-image-builder/issues/149
-    #[root]
-    #transient = true
+    [composefs]
+    enabled = true
     [sysroot]
     readonly = true
     EOF


### PR DESCRIPTION
c9s: Pull in latest bootc/ostree

On general principle, but specifically to enable transient root.

---

Enable transient (composefs) root (again)

This reverts commit 7977ead6e48c89706021aa1c867b5d3757ebeac6 and
effectively migrates the change from https://github.com/CentOS/centos-bootc-dev/pull/27/commits/8f5be0937144b602d8c1fdcaff4c51777b8cb254
to here.

See the linked PR for much more debate, but in a nutshell this
flips around a lot of tradeoffs around the filesystem layout
and will result in a much more easily explained state that
is intended to somewhat more closely match what happens with
a default `podman run --rm` invocation of the container.

Signed-off-by: Colin Walters <walters@verbum.org>

---

