### PR TITLE
c9s: Pull in latest bootc/ostree

### DIFF
--- a/centos-stream-9.yaml
+++ b/centos-stream-9.yaml
@@ -13,4 +13,6 @@ repos:
 repo-packages:
   - repo: appstream-devel
     packages:
+      - bootc
+      - ostree
       - bootupd


### PR DESCRIPTION
On general principle, but specifically to enable transient root.