### PR TITLE
tier-0: enable `kernel-install` cliwrap

### DIFF
--- a/tier-0/kernel-rt.yaml
+++ b/tier-0/kernel-rt.yaml
@@ -8,3 +8,7 @@ packages:
 
 exclude-packages:
   - kernel-rt-debug-core
+
+# until https://github.com/coreos/rpm-ostree/issues/4726
+cliwrap-binaries:
+  - kernel-install

--- a/tier-0/kernel.yaml
+++ b/tier-0/kernel.yaml
@@ -4,3 +4,7 @@ packages:
 
 exclude-packages:
   - kernel-debug
+
+# until https://github.com/coreos/rpm-ostree/issues/4726
+cliwrap-binaries:
+  - kernel-install


### PR DESCRIPTION
Until the native kernel-install is OSTree and container aware[[1]], we need to have a custom `kernel-install` for kernel replacements to work in a derived build.

This will make it so that users don't have to first install the wrappers themselves in their Containerfiles[[2]].

The caveat with this is that if anywhere in the derivation, systemd is updated, the update will retake ownership of `/usr/bin/kernel-install`, which means that a further kernel replacement down the derivation chain would hit issues. We can document that. This still seems worth the UX improvement in the common case.

[1]: https://github.com/coreos/rpm-ostree/issues/4726
[2]: https://github.com/coreos/layering-examples/blob/9329023b/replace-kernel/Containerfile#L4