### PR TITLE
Add a copr for fast tracks

### DIFF
--- a/centos-stream-9.yaml
+++ b/centos-stream-9.yaml
@@ -9,10 +9,11 @@ repos:
   # TODO make a container that tracks this too
   - baseos-devel
   - appstream-devel
+  # ONLY things here to be faster than the devel composes
+  - copr-fedora-bootc-fasttracks
 
 repo-packages:
   - repo: appstream-devel
     packages:
       - bootc
-      - ostree
       - bootupd

--- a/copr-walters-fasttracks.repo
+++ b/copr-walters-fasttracks.repo
@@ -1,0 +1,11 @@
+[copr-fedora-bootc-fasttracks]
+name=Copr repo for fedora-bootc-fasttracks owned by walters
+baseurl=https://download.copr.fedorainfracloud.org/results/walters/fedora-bootc-fasttracks/centos-stream-9-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://download.copr.fedorainfracloud.org/results/walters/fedora-bootc-fasttracks/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1
+


### PR DESCRIPTION
I'd REALLY resisted doing this for a long time, because it basically "forks" us from c9s.  However, the c9s "devel" composes are down to potentially *once a week* due to storage issues.

This one fast tracks https://kojihub.stream.centos.org/koji/buildinfo?buildID=59709