### PR TITLE
docs: Link to new docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ for base operating system updates.
 
 ## More information
 
-See the [project documentation](https://centos.github.io/centos-bootc/).
+See <https://bootc-org.gitlab.io/documentation/>
 
 ## Badges
 

--- a/docs/builds.md
+++ b/docs/builds.md
@@ -2,7 +2,14 @@
 nav_order: 3
 ---
 
-# Configuring systems via container builds
+# This document has moved
+
+See <https://bootc-org.gitlab.io/documentation/>
+
+---
+---
+
+## Configuring systems via container builds
 
 A key part of the idea of this project is that every tool and technique
 one knows for building application container images should apply

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,7 +2,14 @@
 nav_order: 2
 ---
 
-# Trying out development builds
+# This document has moved
+
+See <https://bootc-org.gitlab.io/documentation/>
+
+---
+---
+
+## Trying out development builds
 
 Before you build a [derived container image](https://gitlab.com/bootc-org/examples),
 you may want to just get a feel for the system, try out `bootc`, etc.  The bootable

--- a/docs/related.md
+++ b/docs/related.md
@@ -2,7 +2,14 @@
 nav_order: 4
 ---
 
-# Relationship with other projects
+# This document has moved
+
+See <https://bootc-org.gitlab.io/documentation/>
+
+---
+---
+
+## Relationship with other projects
 
 ## Fedora CoreOS
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,7 +2,14 @@
 nav_order: 3
 ---
 
-# Operating system content and usage
+# This document has moved
+
+See <https://bootc-org.gitlab.io/documentation/>
+
+---
+---
+
+## Operating system content and usage
 
 ## Configuring systemd units
 


### PR DESCRIPTION
I've copied (and slightly cleaned up) all the existing docs into a new dedicated git repository in

https://bootc-org.gitlab.io/documentation/