### PR TITLE
system-configuration: Add cloud-utils-growpart

### DIFF
--- a/tier-1/system-configuration.yaml
+++ b/tier-1/system-configuration.yaml
@@ -12,6 +12,8 @@ packages:
   - e2fsprogs
   - sg3_utils
   - xfsprogs
+  ## This is generally useful... https://github.com/CentOS/centos-bootc/issues/394
+  - cloud-utils-growpart
   # User configuration
   - passwd
   - shadow-utils


### PR DESCRIPTION
This is a relatively small shell script, and was already split out from cloud-init to support use cases like ours.

systemd-repart is a lot nicer but it isn't yet designed for our use case (root is not Discoverable Partition).

Also systemd-repart doesn't handle LVM which this script tries to support.

(IMO the real solution to stuff like this is either Stratis
 or equivalent)