### PR TITLE
ostree: Switch to composefs enabled = yes

### DIFF
--- a/tier-0/ostree.yaml
+++ b/tier-0/ostree.yaml
@@ -8,7 +8,7 @@ postprocess:
     mkdir -p /usr/lib/ostree
     cat > /usr/lib/ostree/prepare-root.conf << EOF
     [composefs]
-    enabled = true
+    enabled = yes
     [sysroot]
     readonly = true
     EOF


### PR DESCRIPTION
This is the opposite workaround for
https://github.com/ostreedev/ostree-rs-ext/issues/612

However, we still need to finally make `/opt` a directory to complete this, which currently wants changes in rpm-ostree. (Or, we could tweak our build process to inject as a container
 afterwards)