### PR TITLE
basic-fixes: Tweak basic-fixes: Tweak tmpfiles.d/provision.conf

### DIFF
--- a/tier-0/basic-fixes.yaml
+++ b/tier-0/basic-fixes.yaml
@@ -24,3 +24,6 @@ postprocess:
     # work if we want to use tmpfiles.d to write to `/root/.ssh` because
     # tmpfiles gives up on that before getting to `/var/roothome`.
     sed -ie 's, /root, /var/roothome,' /usr/lib/tmpfiles.d/provision.conf
+    # Because /var/roothome is also defined in rpm-ostree-0-integration.conf
+    # we need to delete /var/roothome
+    sed -ie '/^d- \/var\/roothome /d' /usr/lib/tmpfiles.d/provision.conf


### PR DESCRIPTION
As a followup for https://github.com/CentOS/centos-bootc/pull/371 this PR tweaks `tmpfiles.d/provision.conf` so
that there is only a single /var/roothome line for tmpfiles.d

As it is both provision.conf and rpm-ostree-0-integration.conf define the same dir.

This should fix https://github.com/containers/bootc/issues/358
