### PR TITLE
ci: Add a Containerfile-based workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -13,10 +13,6 @@ jobs:
   build-image:
     runs-on: ubuntu-latest
 
-    container:
-      image: quay.io/centos-bootc/bootc-image-builder:latest
-      options: --privileged
-
     # Yes, this is a one-element matrix, but we may add c10s in the future soon
     strategy:
       matrix:
@@ -26,10 +22,24 @@ jobs:
             version: stream9
 
     steps:
+      - name: Update podman
+        run: |
+          # from https://askubuntu.com/questions/1414446/whats-the-recommended-way-of-installing-podman-4-in-ubuntu-22-04
+          ubuntu_version='22.04'
+          key_url="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key"
+          sources_url="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}"
+          echo "deb $sources_url/ /" | sudo tee /etc/apt/sources.list.d/devel-kubic-libcontainers-unstable.list
+          curl -fsSL $key_url | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_unstable.gpg > /dev/null
+          sudo apt update
+          sudo apt install -y podman
+
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Build
         run: |
-          rpm-ostree compose image --format=ociarchive \
-          --initialize ${{ matrix.os }}-bootc.yaml dest.oci-archive
+          podman build --security-opt=label=disable --cap-add=all --device /dev/fuse \
+            -t localhost/${{ matrix.os }}-${{ matrix.version }}-bootc -f Containerfile.${{ matrix.os }}-${{ matrix.version }}
+
+      - name: Run image
+        run: podman run --rm -ti localhost/${{ matrix.os }}-${{ matrix.version }}-bootc bootc --help

--- a/Containerfile.centos-stream9
+++ b/Containerfile.centos-stream9
@@ -1,0 +1,41 @@
+# This container build uses some special features of podman that allow
+# a process executing as part of a container build to generate a new container
+# image "from scratch".
+#
+# This container build uses nested containerization, so you must build with e.g.
+# podman build --security-opt=label=disable --cap-add=all --device /dev/fuse <...>
+#
+# # Why are we doing this?
+#
+# Today this base image build process uses rpm-ostree.  There is a lot of things that
+# rpm-ostree does when generating a container image...but important parts include:
+#
+# - auto-updating labels in the container metadata
+# - Generating "chunked" content-addressed reproducible image layers (notice
+#   how there are ~60 layers in the generated image)
+#
+# The latter bit in particular is currently impossible to do from Containerfile.
+# A future goal is adding some support for this in a way that can be honored by
+# buildah (xref https://github.com/containers/podman/discussions/12605)
+#
+# # Why does this build process require additional privileges?
+#
+# Because it's generating a base image and uses containerization features itself.
+# In the future some of this can be lifted.
+
+FROM quay.io/centos/centos:stream9 as repos
+
+FROM quay.io/centos-bootc/bootc-image-builder:latest as builder
+ARG MANIFEST=centos-bootc.yaml
+# XXX: we should just make sure our in-tree c9s repo points to the c9s paths and doesn't require vars to avoid these steps entirely
+COPY --from=repos /etc/dnf/vars /etc/dnf/vars
+COPY --from=repos /etc/yum.repos.d/centos.repo c9s.repo
+COPY --from=repos /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial /etc/pki/rpm-gpg
+# rpm-ostree doesn't honor /etc/dnf/vars right now
+RUN for n in $(ls /etc/dnf/vars); do v=$(cat /etc/dnf/vars/$n); sed -ie s,\$${n},$v, c9s.repo; done
+RUN --mount=type=cache,target=/workdir --mount=type=bind,rw=true,src=.,dst=/buildcontext,bind-propagation=shared rpm-ostree compose image --cachedir=/workdir --format=ociarchive --initialize /buildcontext/${MANIFEST} /buildcontext/out.ociarchive
+
+FROM oci-archive:./out.ociarchive
+# Need to reference builder here to force ordering. But since we have to run
+# something anyway, we might as well cleanup after ourselves.
+RUN --mount=type=bind,from=builder,src=.,target=/var/tmp --mount=type=bind,rw=true,src=.,dst=/buildcontext,bind-propagation=shared rm /buildcontext/out.ociarchive


### PR DESCRIPTION
This is a small but notable step towards making the build process more container native.  The rpm-ostree bits are hidden much more.  At a high level, the build process outputs a "nested container" - a container image with a `/nested.ociarchive` at the top level.

Higher level build processes need not be aware of exactly how that `.ociarchive` is constructed (as it will definitely change in the future).

In an ideal world of course we wouldn't need this "wrapped image" as it runs the ergonomics.  See discussion in e.g. https://github.com/coreos/rpm-ostree/issues/4688
for that.