### PR TITLE
Add a `bootc.diskimage-builder` label

### DIFF
--- a/centos-bootc-config.json
+++ b/centos-bootc-config.json
@@ -1,6 +1,7 @@
 {
     "Labels": {
         "containers.bootc": "1",
+        "bootc.diskimage-builder": "quay.io/centos-bootc/bootc-image-builder",
         "redhat.compose-id": "CentOS-Stream-9-20240304.d.0",
         "redhat.id": "centos",
         "redhat.version-id": "9"

--- a/fedora-bootc-config.json
+++ b/fedora-bootc-config.json
@@ -1,9 +1,0 @@
-{
-    "Labels": {
-        "containers.bootc": "1",
-        "redhat.compose-id": "Fedora-ELN-20240402.2",
-        "redhat.id": "fedora",
-        "redhat.version-id": "ELN"
-    },
-    "StopSignal": "SIGRTMIN+3"
-}


### PR DESCRIPTION
Right now, the relationship between this image and bootc-image-builder is "floating".  However, we may want the ability to more strictly bind the two in the future.

With this, the bootc image links out to the recommended diskimage builder container, so automated tooling can find it instead of hardcoding it.