### PR TITLE
Move eln to its own configs, add rawhide and devel to repos

### DIFF
--- a/fedora-eln-bootc.yaml
+++ b/fedora-eln-bootc.yaml
@@ -1,10 +1,10 @@
-releasever: 40
+releasever: 39
 variables:
-  distro: "fedora"
+  distro: "eln"
 
 repos:
-  - fedora-devel
-  - fedora-updates
+  - eln-baseos
+  - eln-appstream
 
 metadata:
   name: fedora-boot-tier1

--- a/fedora-tier-0-40.yaml
+++ b/fedora-tier-0-40.yaml
@@ -7,9 +7,9 @@ repos:
   - fedora-updates
 
 metadata:
-  name: fedora-boot-tier1
-  summary: Fedora Bootable Tier 1
+  name: fedora-boot-tier0
+  summary: Fedora Bootable Tier 0
 
 include:
-  - tier-1/manifest.yaml
-  - tier-1/kernel.yaml
+  - tier-0/manifest.yaml
+  - tier-0/kernel.yaml

--- a/fedora-tier-0-rawhide.yaml
+++ b/fedora-tier-0-rawhide.yaml
@@ -1,0 +1,14 @@
+releasever: rawhide
+variables:
+  distro: "fedora"
+
+repos:
+  - rawhide
+
+metadata:
+  name: fedora-boot-tier0
+  summary: Fedora Bootable Tier 0
+
+include:
+  - tier-0/manifest.yaml
+  - tier-0/kernel.yaml

--- a/fedora.repo
+++ b/fedora.repo
@@ -74,3 +74,30 @@ gpgcheck=1
 metadata_expire=6h
 gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
 skip_if_unavailable=False
+
+[rawhide]
+name=Fedora - Rawhide - Developmental packages for the next Fedora release
+baseurl=https://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/Everything/$basearch/os/
+        https://dl.fedoraproject.org/pub/fedora-secondary/development/$releasever/Everything/$basearch/os/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
+enabled=1
+#metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
+skip_if_unavailable=False
+
+[fedora-devel]
+name=Fedora $releasever - $basearch
+baseurl=https://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/Everything/$basearch/os/
+        https://dl.fedoraproject.org/pub/fedora-secondary/development/$releasever/Everything/$basearch/os/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
+enabled=1
+#metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
+skip_if_unavailable=False
+


### PR DESCRIPTION

- Move eln to `fedora-eln-bootc` and use `fedora-bootc` for Fedora
- Add `fedora-tier-0-40` and `fedora-tier-0-rawhide` to build Fedora base images
- Add `fedora-devel` and `rawhide` repositories to `fedora.repo`
