### PR TITLE
fedora.repo: Drop trailing whitespace

### DIFF
--- a/fedora.repo
+++ b/fedora.repo
@@ -100,4 +100,3 @@ type=rpm
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
 skip_if_unavailable=False
-


### PR DESCRIPTION
The precommit is a bit annoying.