### PR TITLE
Podman needs Volume: /var/lib/containers/storage to work.

### DIFF
--- a/centos-bootc-config.json
+++ b/centos-bootc-config.json
@@ -6,5 +6,8 @@
         "redhat.id": "centos",
         "redhat.version-id": "9"
     },
-    "StopSignal": "SIGRTMIN+3"
+    "StopSignal": "SIGRTMIN+3",
+    "Volumes": {
+        "/var/lib/containers/storage": {}
+    }
 }

--- a/fedora-bootc-config.json
+++ b/fedora-bootc-config.json
@@ -5,5 +5,8 @@
         "redhat.id": "fedora",
         "redhat.version-id": "40"
     },
-    "StopSignal": "SIGRTMIN+3"
+    "StopSignal": "SIGRTMIN+3",
+    "Volumes": {
+        "/var/lib/containers/storage": {}
+    }
 }


### PR DESCRIPTION
When running a bootc image as an OCI contianer, embeded containers will fail. This is because OSTree on OSTree is not allower. Defaulting i /var/lib/containers/storage to a Volume fixes the problem.