### PR TITLE
build-sys: Sync Containerfiles

### DIFF
--- a/Containerfile.centos-stream10
+++ b/Containerfile.centos-stream10
@@ -7,14 +7,20 @@ ARG MANIFEST=centos-stream-10-tier1.yaml
 RUN --mount=type=bind,rw=true,src=.,dst=/buildcontext,bind-propagation=shared rm -vf /buildcontext/*.repo
 # XXX: we should just make sure our in-tree c9s repo points to the c9s paths and doesn't require vars to avoid these steps entirely
 COPY --from=repos /etc/dnf/vars /etc/dnf/vars
+# The input git repository has .repo files committed to git rpm-ostree has historically
+# emphasized that.  But here, we are fetching the repos from the container base image.
+# So copy the source, and delete the hardcoded ones in git, and use the container base
+# image ones.  We can drop the ones commited to git when we hard switch to Containerfile.
+COPY . /src
+WORKDIR /src
+RUN rm -vf /src/*.repo
 COPY --from=repos /etc/yum.repos.d/centos.repo c10s.repo
 COPY --from=repos /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial /etc/pki/rpm-gpg
 # rpm-ostree doesn't honor /etc/dnf/vars right now
 RUN for n in $(ls /etc/dnf/vars); do v=$(cat /etc/dnf/vars/$n); sed -ie s,\$${n},$v, c10s.repo; done
 RUN --mount=type=cache,target=/workdir --mount=type=bind,rw=true,src=.,dst=/buildcontext,bind-propagation=shared \
-    cp -a /buildcontext /src && rm -vf /src/*.repo && cp -a c10s.repo /src && ls -al /src && \
-    rpm-ostree compose image --image-config /buildcontext/centos-bootc-config.json \
-     --cachedir=/workdir --format=ociarchive --initialize /src/${MANIFEST} /buildcontext/out.ociarchive
+    rpm-ostree compose image --image-config centos-bootc-config.json \
+     --cachedir=/workdir --format=ociarchive --initialize ${MANIFEST} /buildcontext/out.ociarchive
 
 FROM oci-archive:./out.ociarchive
 # Need to reference builder here to force ordering. But since we have to run

--- a/Containerfile.centos-stream9
+++ b/Containerfile.centos-stream9
@@ -29,12 +29,19 @@ FROM quay.io/centos-bootc/bootc-image-builder:latest as builder
 ARG MANIFEST=centos-stream-9-tier1.yaml
 # XXX: we should just make sure our in-tree c9s repo points to the c9s paths and doesn't require vars to avoid these steps entirely
 COPY --from=repos /etc/dnf/vars /etc/dnf/vars
+# The input git repository has .repo files committed to git rpm-ostree has historically
+# emphasized that.  But here, we are fetching the repos from the container base image.
+# So copy the source, and delete the hardcoded ones in git, and use the container base
+# image ones.  We can drop the ones commited to git when we hard switch to Containerfile.
+COPY . /src
+WORKDIR /src
+RUN rm -vf /src/*.repo
 COPY --from=repos /etc/yum.repos.d/centos.repo c9s.repo
 COPY --from=repos /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial /etc/pki/rpm-gpg
 # rpm-ostree doesn't honor /etc/dnf/vars right now
 RUN for n in $(ls /etc/dnf/vars); do v=$(cat /etc/dnf/vars/$n); sed -ie s,\$${n},$v, c9s.repo; done
 RUN --mount=type=cache,target=/workdir --mount=type=bind,rw=true,src=.,dst=/buildcontext,bind-propagation=shared \
-    rpm-ostree compose image --image-config /buildcontext/centos-bootc-config.json --cachedir=/workdir --format=ociarchive --initialize /buildcontext/${MANIFEST} /buildcontext/out.ociarchive
+    rpm-ostree compose image --image-config centos-bootc-config.json --cachedir=/workdir --format=ociarchive --initialize ${MANIFEST} /buildcontext/out.ociarchive
 
 FROM oci-archive:./out.ociarchive
 # Need to reference builder here to force ordering. But since we have to run

--- a/Containerfile.fedora-40
+++ b/Containerfile.fedora-40
@@ -29,11 +29,16 @@ FROM quay.io/centos-bootc/bootc-image-builder:latest as builder
 ARG MANIFEST=fedora-bootc.yaml
 COPY --from=repos /etc/dnf/vars /etc/dnf/vars
 COPY --from=repos /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-* /etc/pki/rpm-gpg
+# The input git repository has .repo files committed to git rpm-ostree has historically
+# emphasized that.  But here, we are fetching the repos from the container base image.
+# So copy the source, and delete the hardcoded ones in git, and use the container base
+# image ones.  We can drop the ones commited to git when we hard switch to Containerfile.
 COPY . /src
+WORKDIR /src
 RUN rm -vf /src/*.repo
 COPY --from=repos /etc/yum.repos.d/*.repo /src
 RUN --mount=type=cache,target=/workdir --mount=type=bind,rw=true,src=.,dst=/buildcontext,bind-propagation=shared rpm-ostree compose image \
- --image-config /buildcontext/fedora-bootc-config.json --cachedir=/workdir --format=ociarchive --initialize /src/${MANIFEST} /buildcontext/out.ociarchive
+ --image-config fedora-bootc-config.json --cachedir=/workdir --format=ociarchive --initialize ${MANIFEST} /buildcontext/out.ociarchive
 
 FROM oci-archive:./out.ociarchive
 # Need to reference builder here to force ordering. But since we have to run


### PR DESCRIPTION
- The centos-stream9 one was removing the `.repo` files from the buildcontext, which is just wrong; we don't want to change the input git repo
- Use WORKDIR /src to simplify things