### PR TITLE
Add subscription-manager

### DIFF
--- a/centos-stream-common.yaml
+++ b/centos-stream-common.yaml
@@ -2,6 +2,9 @@ repos:
   - baseos
   - appstream
 
+packages:
+  - subscription-manager
+
 # Configuration for bootc
 postprocess:
   # XFS is our default filesystem
@@ -12,3 +15,11 @@ postprocess:
     [install]
     root-fs-type = "xfs"
     EOF
+  # These enable librhsm which enables host subscriptions to work in containers
+  # https://github.com/rpm-software-management/librhsm/blob/fcd972cbe7c8a3907ba9f091cd082b1090231492/rhsm/rhsm-context.c#L30
+  # https://github.com/openshift/os/pull/876/commits/dd35dd0e102aeed90df14f05c8ae9da4c8c5962a
+  - |
+    #!/usr/bin/bash
+    set -xeuo pipefail
+    ln -sr /run/secrets/etc-pki-entitlement /etc/pki/entitlement-host
+    ln -sr /run/secrets/rhsm /etc/rhsm-host


### PR DESCRIPTION
This repo is only about the CentOS base images now. Probably should've
been part of 885f277 ("Use fedora-bootc as a git submodule").